### PR TITLE
Added base styling accordions (+ removed red test border)

### DIFF
--- a/style.css
+++ b/style.css
@@ -42,7 +42,7 @@ h5, .h5,
 h6, .h6 {
     margin-top: 22px;
     margin-bottom: 12px;
-    
+
 }
 
 ul {
@@ -89,7 +89,8 @@ h6 a, .h6 a {
     color: #182b49;
 }
 
-ul {
+ul,
+details {
     padding-left: 20px;
 }
 
@@ -699,7 +700,6 @@ code {
 }
 /* Align titles with their wide width blocks */
 h2:has(+ .wp-block-latest-posts__list) {
-	border: red 1px solid;
 	max-width: calc( 100% + 8vw + 8vw );
 	margin-left: -8vw;
 	margin-right: -8vw;
@@ -715,3 +715,15 @@ h2:has(+ .wp-block-latest-posts__list) {
     margin: 40px 0 40px;
     border-bottom: none;
 }
+
+
+details {
+	margin-bottom: 10px;
+}
+details summary:first-of-type {
+	display: list-item;
+	list-style-position: outside;
+	font-weight: bold;
+}
+
+


### PR DESCRIPTION
# Pull Request

## What changed?

- removed red testing border on h2:has(+ .wp-block-latest-posts__list)
- added/fixed base CSS styling for details summary block:
	- display: list-item (normalize.less added a faulty display:block to the summary element)
	- made the 'summary' title bold (cannot target only the summary within the block editor, using bold  makes the whold detail summary block bold)
	- added indent + margin bottom to details summary (consistent with ul styling)


## Why did it change?

- red border was a local testing left-over (excuse me..)
- accordions didn't appear to function (no base styling made them look broken)

## Did you fix any specific issues?

Fixes #24 

## CERTIFICATION

By opening this pull request, I do agree to abide by the [Code of Conduct](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CODE_OF_CONDUCT.md) and be bound by the terms of the [Contribution Guidelines](https://github.com/aspirepress/.github/blob/updating-contributor-policy/CONTRIBUTING.md) in effect on the date and time of my contribution as proven by the revision information in GitHub.

